### PR TITLE
Run first request attempt immediately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode
 venv
 .env
+envs
 *.egg-info
 dist
 __pycache__

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name='spotifyconnector',
     packages=find_packages(include=['spotifyconnector']),
-    version='0.6.0',
+    version='0.7.0',
     description='Spotify Connector for Podcast Data',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/spotifyconnector/__main__.py
+++ b/spotifyconnector/__main__.py
@@ -46,7 +46,7 @@ def main():
     # Fetch podcast episodes
     end = dt.datetime.now()
     start = dt.datetime.now() - dt.timedelta(days=7)
-    # Get all episodes from iterator
+    # Get all episodes from generator
     for episode in connector.episodes(start, end):
         logger.info("Episode = {}", json.dumps(episode, indent=4))
 

--- a/spotifyconnector/connector.py
+++ b/spotifyconnector/connector.py
@@ -26,6 +26,7 @@ import yaml
 
 
 DELAY_BASE = 2.0
+MAX_REQUEST_ATTEMPTS = 6
 
 
 def random_string(
@@ -183,8 +184,7 @@ class SpotifyConnector:
     def _request(self, url: str, *, params: Optional[Dict[str, str]] = None) -> dict:
         logger.trace("url = {}", url)
         delay = DELAY_BASE
-        for attempt in range(6):
-            sleep(delay)
+        for attempt in range(MAX_REQUEST_ATTEMPTS):
             self._ensure_auth()
 
             # Create request object with requests and trace it before sending
@@ -207,6 +207,7 @@ class SpotifyConnector:
                     url,
                     delay,
                 )
+                sleep(delay)
                 continue
 
             elif response.status_code == 401:


### PR DESCRIPTION
Previously we waited for BASE_DELAY before making
the first request attempt, unnecessarily blocking the request.